### PR TITLE
Replace trio.MultiError.filter() with BaseExceptionGroup.split()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ documentation = "https://hypercorn.readthedocs.io"
 [tool.poetry.dependencies]
 python = ">=3.7"
 aioquic = { version = ">= 0.9.0, < 1.0", optional = true }
+exceptiongroup = { version = ">= 1.0.0rc9", python = "<3.11", optional = true }
 h11 = "*"
 h2 = ">=3.1.0"
 priority = "*"


### PR DESCRIPTION
Hypercorn was using `trio.MultiError.filter()` to filter out `trio.Cancelled`. However, if the exception group contained a `BaseExceptionGroup` rather than a `trio.MultiError`, then `trio.MultiError.filter()` wasn't recursing into the `BaseExceptionGroup`. So it would fail to filter out any `trio.Cancelled` that were hidden in the `BaseExceptionGroup`, leading to spurious error messages.

This PR switches from `trio.MultiError.filter()` to `BaseExceptionGroup.split()`.