### PR TITLE
allow disabling the keep_alive_max_requests limit via config

### DIFF
--- a/src/hypercorn/config.py
+++ b/src/hypercorn/config.py
@@ -84,7 +84,7 @@ class Config:
     include_date_header = True
     include_server_header = True
     keep_alive_timeout = 5 * SECONDS
-    keep_alive_max_requests = 1000
+    keep_alive_max_requests: int = 1000  # 0 for disabled
     keyfile: Optional[str] = None
     keyfile_password: Optional[str] = None
     logconfig: Optional[str] = None

--- a/src/hypercorn/protocol/h11.py
+++ b/src/hypercorn/protocol/h11.py
@@ -235,7 +235,8 @@ class H11Protocol:
                 raw_path=request.target,
             )
         )
-        self.keep_alive_requests += 1
+        if self.config.keep_alive_max_requests:
+            self.keep_alive_requests += 1
         await self.context.mark_request()
 
     async def _send_h11_event(self, event: H11SendableEvent) -> None:

--- a/src/hypercorn/protocol/h2.py
+++ b/src/hypercorn/protocol/h2.py
@@ -357,7 +357,6 @@ class H2Protocol:
             self.keep_alive_requests += 1
         await self.context.mark_request()
 
-
     async def _create_server_push(
         self, stream_id: int, path: bytes, headers: List[Tuple[bytes, bytes]]
     ) -> None:


### PR DESCRIPTION
Don't increment the counter if the limit is set to `0`. The limit and the count will then always be 0 and the limit will never be hit.