### PR TITLE
set TCP_NODELAY 1 on listener sockets

### DIFF
--- a/src/hypercorn/config.py
+++ b/src/hypercorn/config.py
@@ -101,6 +101,7 @@ class Config:
     startup_timeout = 60 * SECONDS
     statsd_host: Optional[str] = None
     statsd_prefix = ""
+    tcp_nodelay: bool = False
     umask: Optional[int] = None
     use_reloader = False
     user: Optional[int] = None
@@ -246,7 +247,8 @@ class Config:
                 except (ValueError, IndexError):
                     host, port = bind, 8000
                 sock = socket.socket(socket.AF_INET6 if ":" in host else socket.AF_INET, type_)
-                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                if self.tcp_nodelay:
+                    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
                 if self.workers > 1:
                     try:
                         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)

--- a/src/hypercorn/config.py
+++ b/src/hypercorn/config.py
@@ -246,6 +246,7 @@ class Config:
                 except (ValueError, IndexError):
                     host, port = bind, 8000
                 sock = socket.socket(socket.AF_INET6 if ":" in host else socket.AF_INET, type_)
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
                 if self.workers > 1:
                     try:
                         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)


### PR DESCRIPTION
Disable Nagle's which may improve latency in certain scenarios. This is the default in Trio but the way that the sockets are set up in Hypercorn means we don't get Trio's default socket options.

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/7/html/tuning_guide/tcp_nodelay_and_small_buffer_writes

Probably need to plumb it through with config so we can control roll out without having to revert a change to base image.